### PR TITLE
Update package.json to support modern bundlers like Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./es/UnitMath.js",
   "exports": {
     ".": {
-      "import": "./dist/UnitMath.js",
+      "import": "./es/UnitMath.js",
       "require": "./dist/UnitMath.js"
     }
   },


### PR DESCRIPTION
I tried this library and it works great, but was having some issues with TS and Vite when importing.

![image](https://github.com/user-attachments/assets/383a7117-6acb-4e8c-a50d-f3b23cd87868)

There are some issues with newer versions of TS and Vite that require strict bundling rules. If we point the `import` part of this package to the es bundled code (matching `module`) it should avoid a whole bunch of problems.

Making this change locally fixes this. See here:
![image](https://github.com/user-attachments/assets/d6297c64-8af4-40e7-ba4e-b789704bef0d)
![image](https://github.com/user-attachments/assets/096832ce-384c-491a-8631-85e185a9f543)
